### PR TITLE
refactor: reduce warnings

### DIFF
--- a/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/jazz/ERMSample.java
+++ b/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/jazz/ERMSample.java
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.oauth.OAuthException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.http.HttpHeaders;
@@ -52,7 +52,7 @@ import org.eclipse.lyo.client.exception.RootServicesException;
 import org.eclipse.lyo.client.query.OslcQuery;
 import org.eclipse.lyo.client.query.OslcQueryParameters;
 import org.eclipse.lyo.client.query.OslcQueryResult;
-import org.eclipse.lyo.client.resources.RmUtil;
+import org.eclipse.lyo.client.resources.ResourceShapeClient;
 import org.eclipse.lyo.oslc.domains.rm.Requirement;
 import org.eclipse.lyo.oslc.domains.rm.RequirementCollection;
 import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
@@ -115,7 +115,7 @@ public class ERMSample {
         options.addOption("project", true, "project area");
         options.addOption("b", "basic", false, "Use Basic auth (use if JAS is enabled)");
 
-        CommandLineParser cliParser = new GnuParser();
+        CommandLineParser cliParser = new DefaultParser();
         CommandLine cmd = cliParser.parse(options, args);
 
         if (!validateOptions(cmd)) {
@@ -212,12 +212,9 @@ public class ERMSample {
                         null);
             }
 
-            collectionInstanceShape = RmUtil.lookupRequirementsInstanceShapes(
-                    serviceProviderUrl,
-                    OSLCConstants.OSLC_RM_V2,
-                    OSLCConstants.RM_REQUIREMENT_COLLECTION_TYPE,
-                    client,
-                    "Collection");
+            var shapeClient = new ResourceShapeClient(client);
+            collectionInstanceShape =
+                    shapeClient.lookupRequirementCollectionShape(URI.create(serviceProviderUrl), "Collection");
 
             List<ResourceShape> shapes = new ArrayList<>();
             shapes.add(featureInstanceShape);

--- a/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/jazz/ETMSample.java
+++ b/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/jazz/ETMSample.java
@@ -157,7 +157,7 @@ public class ETMSample {
 
         // STEP 6: Get the Query Capabilities URL so that we can run some OSLC queries
         String queryCapability = client.lookupQueryCapability(
-                serviceProviderUrl, OSLCConstants.OSLC_QM_V2, OSLCConstants.QM_TEST_RESULT);
+                serviceProviderUrl, OSLCConstants.OSLC_QM_V2, OSLCConstants.QM_TEST_RESULT_QUERY);
 
         // SCENARIO A: Query passed TestResults (paged)
         OslcQueryParameters queryParams = new OslcQueryParameters();

--- a/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/jazz/ETMSample.java
+++ b/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/jazz/ETMSample.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.http.HttpHeaders;
@@ -79,7 +79,7 @@ public class ETMSample {
         options.addOption("project", true, "project area");
         options.addOption("b", "basic", false, "Use Basic auth (use if JAS is enabled)");
 
-        CommandLineParser cliParser = new GnuParser();
+        CommandLineParser cliParser = new DefaultParser();
 
         // Parse the command line
         CommandLine cmd = cliParser.parse(options, args);
@@ -157,7 +157,7 @@ public class ETMSample {
 
         // STEP 6: Get the Query Capabilities URL so that we can run some OSLC queries
         String queryCapability = client.lookupQueryCapability(
-                serviceProviderUrl, OSLCConstants.OSLC_QM_V2, OSLCConstants.QM_TEST_RESULT_QUERY);
+                serviceProviderUrl, OSLCConstants.OSLC_QM_V2, OSLCConstants.QM_TEST_RESULT);
 
         // SCENARIO A: Query passed TestResults (paged)
         OslcQueryParameters queryParams = new OslcQueryParameters();

--- a/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/jazz/EWMSample.java
+++ b/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/jazz/EWMSample.java
@@ -31,7 +31,7 @@ import javax.xml.namespace.QName;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.http.HttpHeaders;
@@ -50,13 +50,13 @@ import org.eclipse.lyo.client.query.OslcQuery;
 import org.eclipse.lyo.client.query.OslcQueryParameters;
 import org.eclipse.lyo.client.query.OslcQueryResult;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
+import org.eclipse.lyo.oslc4j.core.OSLC4JConstants;
 import org.eclipse.lyo.oslc4j.core.model.AllowedValues;
 import org.eclipse.lyo.oslc4j.core.model.CreationFactory;
 import org.eclipse.lyo.oslc4j.core.model.Link;
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
 import org.eclipse.lyo.oslc4j.core.model.Property;
 import org.eclipse.lyo.oslc4j.core.model.ResourceShape;
-import org.eclipse.lyo.oslc4j.provider.jena.AbstractOslcRdfXmlProvider;
 import org.glassfish.jersey.apache.connector.ApacheClientProperties;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
@@ -101,7 +101,7 @@ public class EWMSample {
         options.addOption("project", true, "project area");
         options.addOption("b", "basic", false, "Use Basic auth (use if JAS is enabled)");
 
-        CommandLineParser cliParser = new GnuParser();
+        CommandLineParser cliParser = new DefaultParser();
 
         // Parse the command line
         CommandLine cmd = cliParser.parse(options, args);
@@ -119,7 +119,7 @@ public class EWMSample {
         // EWM sometimes will declare a property's type, but leave the value
         // empty, which causes errors when parsed by OSLC4J. Set a system property
         // to tell OSLC4J to skip these invalid values.
-        System.setProperty(AbstractOslcRdfXmlProvider.OSLC4J_STRICT_DATATYPES, "false");
+        System.setProperty(OSLC4JConstants.OSLC4J_STRICT_DATATYPES, "false");
 
         String webContextUrl = cmd.getOptionValue("url");
         String userId = cmd.getOptionValue("user");

--- a/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/jazz/automation/impl/IConstants.java
+++ b/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/jazz/automation/impl/IConstants.java
@@ -30,7 +30,7 @@ public interface IConstants {
     String TYPE_STATUS_RESPONSE = NAMESPACE_URI_JAZZ_AUTO_RQM + "StatusResponse";
     String TYPE_MESSAGE = NAMESPACE_URI_JAZZ_AUTO_RQM + "Message";
 
-    String AUTOMATION_DOMAIN = Oslc_autoDomainConstants.AUTOMATION_DOMAIN;
+    String AUTOMATION_DOMAIN = Oslc_autoDomainConstants.AUTOMATION_NAMSPACE;
     String TYPE_AUTOMATION_REQUEST = Oslc_autoDomainConstants.AUTOMATIONREQUEST_TYPE;
     String TYPE_AUTOMATION_RESULT = Oslc_autoDomainConstants.AUTOMATIONRESULT_TYPE;
     // States and verdicts are not exposed as constants by oslc-domains; build them from the namespace.

--- a/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/oslc4j/CMSample.java
+++ b/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/oslc4j/CMSample.java
@@ -24,7 +24,7 @@ import java.io.InputStreamReader;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.http.HttpStatus;
@@ -68,7 +68,7 @@ public class CMSample {
         options.addOption("password", true, "User's password");
         options.addOption("changeRequestURL", true, "Specific Change Request URL for retrieval scenario");
 
-        CommandLineParser cliParser = new GnuParser();
+        CommandLineParser cliParser = new DefaultParser();
 
         // Parse the command line
         CommandLine cmd = cliParser.parse(options, args);

--- a/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/oslc4j/RMSample.java
+++ b/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/oslc4j/RMSample.java
@@ -23,7 +23,7 @@ import java.io.InputStreamReader;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.http.HttpStatus;
@@ -59,7 +59,7 @@ public class RMSample {
         options.addOption("url", true, "url"); // the OSLC catalog URL
         options.addOption("providerTitle", true, "Service Provider title");
 
-        CommandLineParser cliParser = new GnuParser();
+        CommandLineParser cliParser = new DefaultParser();
 
         // Parse the command line
         CommandLine cmd = cliParser.parse(options, args);

--- a/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/polarion/PolarionSample.java
+++ b/lyo-client-samples/src/main/java/org/eclipse/lyo/samples/client/polarion/PolarionSample.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.http.client.config.CookieSpecs;
@@ -80,7 +80,7 @@ public class PolarionSample {
         options.addOption("token", true, "Personal Access Token (PAT)");
         options.addOption("project", true, "Project Name (Service Provider Title)");
 
-        CommandLineParser cliParser = new GnuParser();
+        CommandLineParser cliParser = new DefaultParser();
 
         try {
             CommandLine cmd = cliParser.parse(options, args);


### PR DESCRIPTION
Changes:

- GnuParser → DefaultParser   
- RmUtil.lookupRequirementsInstanceShapes(...) → new ResourceShapeClient(client).lookupRequirementCollectionShape(...)
- AbstractOslcRdfXmlProvider.OSLC4J_STRICT_DATATYPES  → OSLC4JConstants.OSLC4J_STRICT_DATATYPES
- JenaModelHelper.OSLC4J_STRICT_DATATYPES  →  OSLC4JConstants.OSLC4J_STRICT_DATATYPES                                 
- Oslc_autoDomainConstants.AUTOMATION_DOMAIN   → Oslc_autoDomainConstants.AUTOMATION_NAMSPACE                          